### PR TITLE
Quick fix to change market text to white for dark mode

### DIFF
--- a/src/frplib/cli/__init__.py
+++ b/src/frplib/cli/__init__.py
@@ -21,9 +21,13 @@ def frp():
 @frp.command()
 @click.option('-a', '--ascii-only', is_flag=True, show_default=True, default=False,
               help="Produce ASCII output only, no rich text.")
-def market(ascii_only: bool):
+@click.option('-d', '--dark-mode', is_flag=True, show_default=True, default=False,
+              help="Changes text color to suit dark colored terminals")
+def market(ascii_only: bool, dark_mode: bool):
     if ascii_only:
         environment.on_ascii_only()
+    if dark_mode:
+        environment.on_dark_mode()
     click.echo(f'This is the market. Use "exit." to end your session and "help." for help.')
     market_repl()
 

--- a/src/frplib/env.py
+++ b/src/frplib/env.py
@@ -28,6 +28,7 @@ class Environment:
     """Options governing interactive sessions, globally available.
     """
     ascii_only: bool = False
+    dark_mode: bool = False
     is_interactive: bool = False
     console: Console = Console(highlight=True, theme=bright_theme)  # ATTN: auto-detect dark?
 
@@ -38,6 +39,14 @@ class Environment:
     def off_ascii_only(self) -> None:
         "Allow non-ascii and rich output"
         self.ascii_only = False
+
+    def on_dark_mode(self) -> None:
+        "Changes text color to suit dark colored terminals"
+        self.dark_mode = True
+
+    def off_dark_mode(self) -> None:
+        "Text color default suited for light colored terminals"
+        self.dark_mode = False
 
     def interactive_mode(self, ascii=None) -> None:
         "Indicate that this session is interactive. No need to turn this off."

--- a/src/frplib/repls/market.py
+++ b/src/frplib/repls/market.py
@@ -188,6 +188,8 @@ class CommandValidator(Validator):
 def emit(*a, **kw) -> None:
     environment.console.print(*a, **kw)
 
+# Potentially add a completely separate color scheme for dark mode
+text_color = "white" if environment.dark_mode else "black"
 command_style = Style.from_dict({  # ATTN:TEMP Colors for teting
     'pygments.command': "steelblue bold",
     'pygments.connective': "#777777",  # "#430363",
@@ -197,11 +199,11 @@ command_style = Style.from_dict({  # ATTN:TEMP Colors for teting
     'pygments.count': "#91011e",
     'pygments.node': "#0240a3",
     'pygments.weight': "#047d40 italic",  # "#016935",
-    'pygments.other':  "black",
+    'pygments.other': text_color,
     'prompt': "#4682b4",
     'parse.parsed': '#71716f',
     'parse.error': '#ff0f0f bold',
-    '': 'black',
+    '': text_color,
 })
 
 def continuation_prompt(prompt_width: int, line_number: int, wrap_count: int) -> FormattedText:


### PR DESCRIPTION
This is a quick fix to add the ability for people to see white text in the `market` rather than black text.

I don't actually know if this works though because I can't run it locally, so I wouldn't be surprised if this doesn't work right now, but I doubt it would be too hard to fix.

These changes are a quick fix (changing black text to white), but it might be reasonable to change other colors as well to match a dark background.